### PR TITLE
Fix Makefile variable precedence to respect .env configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ ifneq (,$(wildcard ./.env))
 endif
 
 # Configuration
-HA_HOST = your_homeassistant_host
-HA_REMOTE_PATH = /config/
-LOCAL_CONFIG_PATH = config/
-BACKUP_DIR = backups
-VENV_PATH = venv
-TOOLS_PATH = tools
+HA_HOST ?= your_homeassistant_host
+HA_REMOTE_PATH ?= /config/
+LOCAL_CONFIG_PATH ?= config/
+BACKUP_DIR ?= backups
+VENV_PATH ?= venv
+TOOLS_PATH ?= tools
 
 # Colors for output
 GREEN = \033[0;32m


### PR DESCRIPTION
Getting this error when trying `make pull`:

```
Pulling configuration from Home Assistant...
ssh: Could not resolve hostname your_homeassistant_host: nodename nor servname provided, or not known
rsync(30155): error: unexpected end of file
rsync(30155): error: io_read_nonblocking
rsync(30155): error: io_read_buf
rsync(30155): error: io_read_int
rsync(30155): warning: child 30156 exited with status 255
make: *** [pull] Error 255
```

Was a little suspicious when I saw `your_homeassistant_host` because clearly that is not what I put in the .env file.
Looking at the Makefile:

```
# Load environment variables from .env file
ifneq (,$(wildcard ./.env))
    include .env
    export
endif

# Configuration
HA_HOST = your_homeassistant_host
HA_REMOTE_PATH = /config/
LOCAL_CONFIG_PATH = config/
BACKUP_DIR = backups
VENV_PATH = venv
TOOLS_PATH = tools
```

You are loading the .env file but then always hardcoding / overwriting the HA_HOST to `your_homeassistant_host` by using `=` instead of using a conditional assignment `?=` in the Makefile which would respect the value for HA_HOST has already been assigned (in the .env file). Of course it would make sense to handle this differently altogether since the HA_HOST **has to be set** in the .env making the HA_HOST reference in the Makefile obsolete in any case. But for the optional variables `?=` should be used.