### PR TITLE
Add include_dir_named as a valid config options

### DIFF
--- a/tools/ha_config_validator.py
+++ b/tools/ha_config_validator.py
@@ -24,6 +24,10 @@ def include_constructor(loader, node):
     filename = loader.construct_scalar(node)
     return f"!include {filename}"
 
+def include_dir_named_constructor(loader, node):
+    """Handle !include_dir_named tag."""
+    dirname = loader.construct_scalar(node)
+    return f"!include_dir_named {dirname}"
 
 def include_dir_merge_named_constructor(loader, node):
     """Handle !include_dir_merge_named tag."""
@@ -57,6 +61,9 @@ def secret_constructor(loader, node):
 
 # Register custom constructors
 HAYamlLoader.add_constructor("!include", include_constructor)
+HAYamlLoader.add_constructor(
+    "!include_dir_named", include_dir_named_constructor
+)
 HAYamlLoader.add_constructor(
     "!include_dir_merge_named", include_dir_merge_named_constructor
 )

--- a/tools/reference_validator.py
+++ b/tools/reference_validator.py
@@ -34,6 +34,12 @@ def include_constructor(loader, node):
     return f"!include {filename}"
 
 
+def include_dir_named_constructor(loader, node):
+    """Handle !include_dir_named tag."""
+    dirname = loader.construct_scalar(node)
+    return f"!include_dir_named {dirname}"
+
+
 def include_dir_merge_named_constructor(loader, node):
     """Handle !include_dir_merge_named tag."""
     dirname = loader.construct_scalar(node)
@@ -66,6 +72,9 @@ def secret_constructor(loader, node):
 
 # Register custom constructors
 HAYamlLoader.add_constructor("!include", include_constructor)
+HAYamlLoader.add_constructor(
+    "!include_dir_named", include_dir_named_constructor
+)
 HAYamlLoader.add_constructor(
     "!include_dir_merge_named", include_dir_merge_named_constructor
 )

--- a/tools/yaml_validator.py
+++ b/tools/yaml_validator.py
@@ -20,6 +20,11 @@ def include_constructor(loader, node):
     return f"!include {filename}"
 
 
+def include_dir_named_constructor(loader, node):
+    """Handle !include_dir_named tag."""
+    dirname = loader.construct_scalar(node)
+    return f"!include_dir_named {dirname}"
+
 def include_dir_merge_named_constructor(loader, node):
     """Handle !include_dir_merge_named tag."""
     dirname = loader.construct_scalar(node)
@@ -54,6 +59,9 @@ def secret_constructor(loader, node):
 HAYamlLoader.add_constructor("!include", include_constructor)
 HAYamlLoader.add_constructor(
     "!include_dir_merge_named", include_dir_merge_named_constructor
+)
+HAYamlLoader.add_constructor(
+    "!include_dir_named", include_dir_named_constructor
 )
 HAYamlLoader.add_constructor(
     "!include_dir_merge_list", include_dir_merge_list_constructor


### PR DESCRIPTION
It is used by key master and is supported as described here https://community.home-assistant.io/t/include-filename-yaml-or-four-advanced-options-to-include-whole-directories-at-once/48307