### PR TITLE
Fix: Skip template expressions in device validation.

### DIFF
--- a/tools/reference_validator.py
+++ b/tools/reference_validator.py
@@ -273,11 +273,11 @@ class ReferenceValidator:
                 if key in ["device_id", "device_ids"]:
                     if isinstance(value, str):
                         # Skip blueprint inputs and other HA tags
-                        if not value.startswith("!"):
+                        if not value.startswith("!") and not self.is_template(value):
                             devices.add(value)
                     elif isinstance(value, list):
                         for device in value:
-                            if isinstance(device, str) and not device.startswith("!"):
+                            if isinstance(device, str) and not device.startswith("!") and not self.is_template(device):
                                 devices.add(device)
                 else:
                     devices.update(self.extract_device_references(value))
@@ -297,7 +297,7 @@ class ReferenceValidator:
                 if key in ["area_id", "area_ids"]:
                     if isinstance(value, str):
                         # Skip blueprint inputs and other HA tags
-                        if not value.startswith("!"):
+                        if not value.startswith("!") and not self.is_template(value):
                             areas.add(value)
                     elif isinstance(value, list):
                         for area in value:


### PR DESCRIPTION
This small change prevents false positive validation errors when automations use template variables in `device_id` fields - a common pattern for applying a single automation to multiple devices.

**Problem:**
The validator incorrectly flagged `device_id: "{{ device_id_pressed }}"` as an unknown device, even when `device_id_pressed` was properly defined in the automation's `variables` section.

**Solution:**
Added `and not self.is_template(value)` checks to skip validation of template expressions in device references, similar to how entity references are already handled.

**Changes:**
- Modified `extract_device_references()` to skip template expressions
- Three-line change leveraging existing `is_template()` method

**Testing:**
- Verified fix resolves false positives on automations using `{{ trigger.event.data.device_id }}`
- Existing validation functionality remains intact