### PR TITLE
Add configurable RSYNC_SUDO option with auto-detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ BACKUP_DIR=backups
 VENV_PATH=venv
 TOOLS_PATH=tools
 
+# Rsync Configuration (optional)
+# Set to true if rsync needs sudo on Home Assistant (common with HA OS)
+# Run 'make check-rsync' to auto-detect if this is needed
+# RSYNC_SUDO=true
+
 # Instructions:
 # 1. Copy this file to .env in your project root: cp public/.env.example .env
 # 2. Edit .env with your actual Home Assistant details

--- a/README.md
+++ b/README.md
@@ -251,10 +251,11 @@ xcode-select --install  # Installs Command Line Tools including make
 
 ### Configuration Management
 ```bash
-make pull      # Pull latest config from Home Assistant
-make push      # Push local config to HA (with validation)
-make backup    # Create timestamped backup
-make validate  # Run all validation tests
+make pull        # Pull latest config from Home Assistant
+make push        # Push local config to HA (with validation)
+make backup      # Create timestamped backup
+make validate    # Run all validation tests
+make check-rsync # Test rsync permissions (detects if sudo needed)
 ```
 
 ### Entity Discovery
@@ -374,6 +375,17 @@ The entity explorer helps you understand what's available:
 2. Verify entity references: `. venv/bin/activate && python tools/reference_validator.py`
 3. Check HA logs if official validation fails
 
+### Rsync Permission Issues
+
+If `make pull` or `make push` fails with permission errors like:
+```
+rsync: [receiver] mkstemp "..." failed: Permission denied (13)
+```
+
+**Quick fix:** Run `make check-rsync` to auto-detect if sudo is needed, then add `RSYNC_SUDO=true` to your `.env` file if recommended.
+
+This is common with Home Assistant OS where configuration files are owned by root.
+
 ### SSH Connection Issues
 
 <details>
@@ -470,7 +482,29 @@ LOCAL_CONFIG_PATH=config/                # Local config directory
 BACKUP_DIR=backups                       # Backup directory
 VENV_PATH=venv                          # Python virtual environment path
 TOOLS_PATH=tools                        # Tools directory
+
+# Rsync Configuration (optional)
+RSYNC_SUDO=true                         # Enable if rsync needs sudo on HA
 ```
+
+#### Rsync Sudo Mode
+
+Some Home Assistant installations (especially **Home Assistant OS**) require elevated permissions for rsync to access configuration files. If you encounter permission errors during `make pull` or `make push`, you may need to enable sudo mode.
+
+**Auto-detect if sudo is needed:**
+```bash
+make check-rsync
+```
+
+This command tests your rsync connection and tells you whether `RSYNC_SUDO=true` is required.
+
+**When to enable RSYNC_SUDO:**
+- **Home Assistant OS**: Usually required (config files owned by root)
+- **Home Assistant Container**: Usually required (depends on container setup)
+- **Home Assistant Core**: Usually NOT required (files owned by your user)
+- **Home Assistant Supervised**: Depends on your setup
+
+**To enable:** Add `RSYNC_SUDO=true` to your `.env` file.
 
 ### Claude Code Settings
 Located in `.claude-code/settings.json`:


### PR DESCRIPTION
## Summary

This PR adds a configurable `RSYNC_SUDO` option as an improved alternative to PR #27's hardcoded approach.

**Key features:**
- **Configurable**: Users enable sudo mode only when needed via `.env`
- **Auto-detection**: New `make check-rsync` command tests permissions and tells users if sudo is needed
- **Non-breaking**: Users who don't need sudo continue working without changes
- **Well-documented**: Clear guidance on when to enable (HA OS vs Core vs Container)

## Changes

- **Makefile**: 
  - Add `RSYNC_SUDO` variable with conditional `--rsync-path` option
  - Add `check-rsync` target for auto-detection
  - Update `pull`, `push`, `pull-storage` to use configurable rsync path

- **README.md**:
  - Document RSYNC_SUDO configuration
  - Add "Rsync Sudo Mode" section explaining when it's needed
  - Add troubleshooting section for permission errors

- **.env.example**:
  - Add commented RSYNC_SUDO option with explanation

## Usage

```bash
# Auto-detect if sudo is needed
make check-rsync

# If needed, add to .env:
echo 'RSYNC_SUDO=true' >> .env
```

## Test plan

- [ ] Test `make check-rsync` on a system that needs sudo
- [ ] Test `make check-rsync` on a system that doesn't need sudo
- [ ] Test `make pull` with `RSYNC_SUDO=true`
- [ ] Test `make push` with `RSYNC_SUDO=true`
- [ ] Verify existing setups still work without setting RSYNC_SUDO

## Related

Supersedes PR #27 with a configurable approach instead of hardcoding sudo for all users.