### PR TITLE
Fix: Require Python 3.12+ to prevent build errors on macOS

### DIFF
--- a/Makefile.dev
+++ b/Makefile.dev
@@ -5,7 +5,7 @@
 include Makefile
 
 # Development-specific variables
-PYTHON = python3.11
+PYTHON = python3.12
 PIP = pip
 VENV_ACTIVATE = source venv/bin/activate
 TEST_DIR = tests

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -96,7 +96,7 @@ make -f Makefile.dev dev-clean-dev
 
 ### Black (Code Formatting)
 - Line length: 88 characters
-- Target Python version: 3.11+
+- Target Python version: 3.12+
 - Automatically formats all Python files
 
 ### isort (Import Sorting)

--- a/README.md
+++ b/README.md
@@ -369,6 +369,16 @@ The entity explorer helps you understand what's available:
 
 ## 🐛 Troubleshooting
 
+### Build Error: lru-dict or Other C Extensions (macOS)
+If you see errors like `Building wheel for lru-dict... error` during `make setup`, you likely have an old Python version from Xcode Command Line Tools.
+
+**Solution**: Install Python 3.12+ via Homebrew:
+```bash
+brew install python@3.12
+export PATH="/opt/homebrew/bin:$PATH"
+```
+Then run `make setup` again. Home Assistant 2024.x requires Python 3.12+.
+
 ### Validation Errors
 1. Check YAML syntax first: `. venv/bin/activate && python tools/yaml_validator.py`
 2. Verify entity references: `. venv/bin/activate && python tools/reference_validator.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Home Assistant configuration management and validation tools"
 authors = [
     {name = "Home Assistant Config Management"}
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "homeassistant>=2024.1.0",
     "voluptuous>=0.14.0",
@@ -32,7 +32,7 @@ dev = [
 
 [tool.black]
 line-length = 88
-target-version = ['py311']
+target-version = ['py312']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -68,7 +68,7 @@ extend_skip_glob = ["venv/*", "config/*", "temp/*"]
 # Note: flake8 configuration is in .flake8 file (doesn't support pyproject.toml)
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_unused_configs = true
 # Relaxed settings for existing codebase
 disallow_untyped_defs = false

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -22,21 +22,34 @@ command_exists() {
 
 echo "🔍 Checking prerequisites..."
 
-# Check if Python 3.8+ is available
+# Check if Python 3.12+ is available (required by Home Assistant 2024.x)
 if ! command_exists python3; then
     echo "❌ Python 3 is not installed."
-    echo "Please install Python from https://www.python.org/downloads/"
-    echo "Or use Homebrew: brew install python3"
+    echo ""
+    echo "Install Python 3.12+ via Homebrew (recommended):"
+    echo "   brew install python@3.12"
+    echo ""
+    echo "Then run this script again."
     exit 1
 fi
 
-# Check Python version
+# Check Python version - Home Assistant 2024.x requires Python 3.12+
 PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-REQUIRED_VERSION="3.8"
 
-if ! python3 -c "import sys; exit(0 if sys.version_info >= (3, 8) else 1)"; then
-    echo "❌ Python $PYTHON_VERSION found, but Python 3.8+ is required."
-    echo "Please upgrade Python from https://www.python.org/downloads/"
+if ! python3 -c "import sys; exit(0 if sys.version_info >= (3, 12) else 1)"; then
+    echo "❌ Python $PYTHON_VERSION found, but Python 3.12+ is required."
+    echo ""
+    echo "Home Assistant 2024.x requires Python 3.12 or newer."
+    echo "The system Python from Xcode Command Line Tools is typically too old"
+    echo "and may cause build errors with C extensions."
+    echo ""
+    echo "Install Python 3.12+ via Homebrew:"
+    echo "   brew install python@3.12"
+    echo ""
+    echo "After installation, ensure Homebrew Python is in your PATH:"
+    echo "   export PATH=\"/opt/homebrew/bin:\$PATH\""
+    echo ""
+    echo "Then run this script again."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Fixes #26 - Build error on macOS Tahoe with `lru-dict` wheel compilation failure.

### Root Cause

Users with Python 3.9 from macOS Xcode Command Line Tools encounter C extension build failures:
- Newer macOS versions (Tahoe/Sequoia) have stricter Clang compiler settings
- The `lru-dict` package's C code triggers `-Werror=incompatible-function-pointer-types`
- pip falls back to building from source instead of using pre-built wheels

### Why Python 3.12+ Fixes This

1. **Pre-built wheels**: Python 3.12 from Homebrew properly matches pre-built binary wheels for `lru-dict` and other C extensions, so no compilation is needed
2. **Home Assistant requirement**: Home Assistant 2024.x requires Python 3.12+ anyway, so Python 3.9 wouldn't work correctly even if the build succeeded

### Changes

- **`setup-mac.sh`**: Updated minimum Python version from 3.8 to 3.12 with clear Homebrew installation instructions
- **`README.md`**: Added troubleshooting section explaining the fix

## Test plan

- [ ] Run `./setup-mac.sh` with Python 3.9 (should show clear error with Homebrew instructions)
- [ ] Run `./setup-mac.sh` with Python 3.12+ from Homebrew (should succeed)
- [ ] Run `make setup` with Python 3.12+ (should install all dependencies without build errors)