### PR TITLE
feat: separate rsync excludes for pull vs push operations

### DIFF
--- a/.rsync-excludes-pull
+++ b/.rsync-excludes-pull
@@ -1,0 +1,21 @@
+# ===========================================
+# RSYNC EXCLUDES FOR: make pull (HA → Local)
+# Less restrictive - pull most files for backup
+# ===========================================
+
+# Database files (too large, not needed locally)
+home-assistant_v2.db*
+*.db-shm
+*.db-wal
+
+# Log files - INCLUDED for debugging/review
+# *.log*
+
+# Cache directories (regenerated automatically)
+deps/
+tts/
+__pycache__/
+
+# Temporary files
+*.tmp
+*.temp

--- a/.rsync-excludes-push
+++ b/.rsync-excludes-push
@@ -1,0 +1,37 @@
+# ===========================================
+# RSYNC EXCLUDES FOR: make push (Local → HA)
+# MORE RESTRICTIVE - Protect HA's runtime state!
+# ===========================================
+
+# Database files
+home-assistant_v2.db*
+*.db-shm
+*.db-wal
+
+# Log files
+*.log*
+
+# Runtime/cache directories
+custom_components/
+custom_icons/
+themes/
+.cloud/
+deps/
+tts/
+.uuid
+__pycache__/
+
+# Temporary files
+*.tmp
+*.temp
+
+# ===========================================
+# CRITICAL: NEVER PUSH .storage/ TO HA
+# These contain runtime state that HA manages:
+# - Integration configs (Shelly, Tuya, etc.)
+# - Entity/device registries (renames, disables)
+# - Dashboards created via UI
+# - Authentication and sessions
+# All changes should be made via HA UI or API
+# ===========================================
+.storage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This repository manages Home Assistant configuration files with automated validation, testing, and deployment.
 
+## Before Making Changes
+
+**Always consult the latest Home Assistant documentation** at https://www.home-assistant.io/docs/ before suggesting configurations, automations, or integrations. HA updates frequently and syntax/features change between versions.
+
 ## Project Structure
 
 - `config/` - Contains all Home Assistant configuration files (synced from HA instance)
@@ -12,6 +16,77 @@ This repository manages Home Assistant configuration files with automated valida
 - `.claude-code/` - Project-specific Claude Code settings and hooks
   - `hooks/` - Validation hooks that run automatically
   - `settings.json` - Project configuration
+
+## Rsync Architecture
+
+This project uses **two separate exclude files** for different sync operations:
+
+| File | Used By | Purpose |
+|------|---------|---------|
+| `.rsync-excludes-pull` | `make pull` | Less restrictive |
+| `.rsync-excludes-push` | `make push` | More restrictive |
+
+**Why separate files?**
+- `make pull` downloads everything including `.storage/` so you have a local reference for what's available
+- `make push` writes never overwrites HA's runtime state (`.storage/`)
+
+## What This Repo Can and Cannot Manage
+
+### SAFE TO MANAGE (YAML files)
+- `automations.yaml` - Automation definitions
+- `scenes.yaml` - Scene definitions
+- `scripts.yaml` - Script definitions
+- `configuration.yaml` - Main configuration
+- `secrets.yaml` - Secret values
+
+### NEVER MODIFY LOCALLY (Runtime State)
+These files in `.storage/` are managed by Home Assistant at runtime. Local modifications will be **overwritten** by HA on restart or ignored entirely.
+
+### Making Persistent Entity/Device Changes
+
+**Method 1: Home Assistant UI**
+- Settings → Devices & Services → Entities → Edit
+
+**Method 2: WebSocket API**
+```python
+import websockets
+import json
+
+async with websockets.connect('ws://HA_HOST:8123/api/websocket') as ws:
+    # Authenticate
+    await ws.recv()
+    await ws.send(json.dumps({"type": "auth", "access_token": TOKEN}))
+    await ws.recv()
+    
+    # Example: Disable an entity
+    await ws.send(json.dumps({
+        "id": 1,
+        "type": "config/entity_registry/update",
+        "entity_id": "sensor.example",
+        "disabled_by": "user"
+    }))
+```
+
+### Reloading After YAML Changes
+- Automations: `POST /api/services/automation/reload`
+- Scenes: `POST /api/services/scene/reload`
+- Scripts: `POST /api/services/script/reload`
+
+## Workflow Rules
+
+### Before Making Changes
+1. Run `make pull` to ensure local files are current
+2. Identify if the change affects YAML files or `.storage/` files
+3. YAML files → edit locally, then `make push`
+4. `.storage/` files → use HA UI or WebSocket API
+
+### Before Running `make push`
+1. Validation runs automatically - do not push if validation fails
+2. Only YAML configuration files will be synced (`.storage/` is protected)
+
+### After `make push`
+1. Reload the relevant HA components (automations, scenes, scripts)
+2. Verify changes took effect in HA
 
 ## Available Commands
 
@@ -90,6 +165,7 @@ The system tracks entities across these domains:
 - **Secrets are skipped** during validation for security
 - **SSH access required** for pull/push operations
 - **Python venv required** for validation tools
+- All python tools need to be run with `source venv/bin/activate && python <tool_path>`
 
 ## Troubleshooting
 
@@ -159,5 +235,3 @@ vacuum.office_roborock
 - When creating automations, always ask the user for input if there are multiple choices for sensors or devices
 - Use the entity explorer tools to discover available entities before writing automations
 - Follow the naming convention when suggesting entity names in automations
-
-- All python tools need to be run with  `source venv/bin/activate && python <tool_path>`

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help:
 # Pull configuration from Home Assistant
 pull: check-env
 	@echo "$(GREEN)Pulling configuration from Home Assistant...$(NC)"
-	@rsync -avz --delete --exclude-from=.rsync-excludes $(HA_HOST):$(HA_REMOTE_PATH) $(LOCAL_CONFIG_PATH)
+	@rsync -avz --delete --exclude-from=.rsync-excludes-pull $(HA_HOST):$(HA_REMOTE_PATH) $(LOCAL_CONFIG_PATH)
 	@echo "$(GREEN)Configuration pulled successfully!$(NC)"
 	@echo "$(YELLOW)Running validation to ensure integrity...$(NC)"
 	@$(MAKE) validate
@@ -53,7 +53,7 @@ push: check-env
 	@echo "$(GREEN)Validating configuration before push...$(NC)"
 	@$(MAKE) validate
 	@echo "$(GREEN)Validation passed! Pushing to Home Assistant...$(NC)"
-	@rsync -avz --delete --exclude-from=.rsync-excludes $(LOCAL_CONFIG_PATH) $(HA_HOST):$(HA_REMOTE_PATH)
+	@rsync -avz --delete --exclude-from=.rsync-excludes-push $(LOCAL_CONFIG_PATH) $(HA_HOST):$(HA_REMOTE_PATH)
 	@echo "$(GREEN)Configuration pushed successfully!$(NC)"
 	@echo "$(GREEN)Reloading Home Assistant configuration...$(NC)"
 	@. $(VENV_PATH)/bin/activate && python $(TOOLS_PATH)/reload_config.py

--- a/tools/test_rsync_excludes.py
+++ b/tools/test_rsync_excludes.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Test suite for rsync exclude files configuration.
+
+Validates that:
+1. Both exclude files exist
+2. Push excludes protect .storage/ directory
+3. Pull excludes allow .storage/ directory
+4. Makefile references correct exclude files
+"""
+
+import sys
+from pathlib import Path
+
+
+class RsyncExcludesTest:
+    """Test rsync exclude files configuration."""
+
+    def __init__(self, project_root: str = "."):
+        """Initialize the test."""
+        self.project_root = Path(project_root).resolve()
+        self.errors = []
+        self.warnings = []
+
+    def test_exclude_files_exist(self) -> bool:
+        """Test that both exclude files exist."""
+        pull_excludes = self.project_root / ".rsync-excludes-pull"
+        push_excludes = self.project_root / ".rsync-excludes-push"
+
+        passed = True
+
+        if not pull_excludes.exists():
+            self.errors.append(".rsync-excludes-pull file not found")
+            passed = False
+        else:
+            print("  ✓ .rsync-excludes-pull exists")
+
+        if not push_excludes.exists():
+            self.errors.append(".rsync-excludes-push file not found")
+            passed = False
+        else:
+            print("  ✓ .rsync-excludes-push exists")
+
+        return passed
+
+    def test_push_excludes_protect_storage(self) -> bool:
+        """Test that push excludes protect .storage/ directory."""
+        push_excludes = self.project_root / ".rsync-excludes-push"
+
+        if not push_excludes.exists():
+            self.errors.append("Cannot test: .rsync-excludes-push not found")
+            return False
+
+        content = push_excludes.read_text()
+
+        # Check for .storage/ protection
+        if ".storage/" in content or ".storage" in content:
+            print("  ✓ .rsync-excludes-push protects .storage/")
+            return True
+        else:
+            self.errors.append(
+                ".rsync-excludes-push does NOT protect .storage/ - "
+                "this will cause HA runtime state to be overwritten!"
+            )
+            return False
+
+    def test_pull_excludes_allow_storage(self) -> bool:
+        """Test that pull excludes allow .storage/ directory (not excluded)."""
+        pull_excludes = self.project_root / ".rsync-excludes-pull"
+
+        if not pull_excludes.exists():
+            self.errors.append("Cannot test: .rsync-excludes-pull not found")
+            return False
+
+        content = pull_excludes.read_text()
+        lines = [
+            line.strip()
+            for line in content.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+
+        # Check that .storage/ is NOT excluded (or only specific files within)
+        storage_excluded = False
+        for line in lines:
+            # Check for blanket .storage/ exclusion
+            if line == ".storage/" or line == ".storage":
+                storage_excluded = True
+                break
+
+        if storage_excluded:
+            self.warnings.append(
+                ".rsync-excludes-pull excludes entire .storage/ - "
+                "consider allowing it for local backup/reference"
+            )
+            print("  ⚠ .rsync-excludes-pull excludes .storage/ (warning)")
+            return True  # Not a failure, just a warning
+        else:
+            print("  ✓ .rsync-excludes-pull allows .storage/ for backup")
+            return True
+
+    def test_makefile_uses_correct_excludes(self) -> bool:
+        """Test that Makefile references the correct exclude files."""
+        makefile = self.project_root / "Makefile"
+
+        if not makefile.exists():
+            self.errors.append("Makefile not found")
+            return False
+
+        content = makefile.read_text()
+        passed = True
+
+        # Check pull uses -pull excludes
+        if "exclude-from=.rsync-excludes-pull" in content:
+            print("  ✓ Makefile pull uses .rsync-excludes-pull")
+        else:
+            self.errors.append("Makefile pull does not use .rsync-excludes-pull")
+            passed = False
+
+        # Check push uses -push excludes
+        if "exclude-from=.rsync-excludes-push" in content:
+            print("  ✓ Makefile push uses .rsync-excludes-push")
+        else:
+            self.errors.append("Makefile push does not use .rsync-excludes-push")
+            passed = False
+
+        return passed
+
+    def test_push_excludes_critical_files(self) -> bool:
+        """Test that push excludes protect critical HA files."""
+        push_excludes = self.project_root / ".rsync-excludes-push"
+
+        if not push_excludes.exists():
+            return False
+
+        content = push_excludes.read_text()
+
+        # Critical files that should be protected
+        critical_patterns = [
+            ".storage/",  # Entire storage directory
+        ]
+
+        # Optional but recommended protections
+        recommended_patterns = [
+            "home-assistant_v2.db",
+            "*.log",
+        ]
+
+        passed = True
+
+        # Check critical patterns
+        for pattern in critical_patterns:
+            if pattern in content:
+                print(f"  ✓ Push excludes protect: {pattern}")
+            else:
+                self.errors.append(f"Push excludes missing critical pattern: {pattern}")
+                passed = False
+
+        # Check recommended patterns (warnings only)
+        for pattern in recommended_patterns:
+            if pattern in content or pattern.replace("*", "") in content:
+                print(f"  ✓ Push excludes protect: {pattern}")
+            else:
+                self.warnings.append(f"Consider adding to push excludes: {pattern}")
+
+        return passed
+
+    def run(self) -> bool:
+        """Run all tests."""
+        print("🔍 Testing Rsync Exclude Files Configuration")
+        print("=" * 50)
+        print()
+
+        all_passed = True
+
+        tests = [
+            ("Exclude files exist", self.test_exclude_files_exist),
+            ("Push excludes protect .storage/", self.test_push_excludes_protect_storage),
+            ("Pull excludes allow .storage/", self.test_pull_excludes_allow_storage),
+            ("Makefile uses correct excludes", self.test_makefile_uses_correct_excludes),
+            ("Push excludes critical files", self.test_push_excludes_critical_files),
+        ]
+
+        for test_name, test_func in tests:
+            print(f"\n📋 {test_name}")
+            print("-" * 40)
+            try:
+                if not test_func():
+                    all_passed = False
+            except Exception as e:
+                self.errors.append(f"Test '{test_name}' threw exception: {e}")
+                all_passed = False
+
+        # Print summary
+        print("\n" + "=" * 50)
+        print("📊 TEST SUMMARY")
+        print("=" * 50)
+
+        if self.errors:
+            print(f"\n❌ ERRORS ({len(self.errors)}):")
+            for error in self.errors:
+                print(f"   • {error}")
+
+        if self.warnings:
+            print(f"\n⚠️  WARNINGS ({len(self.warnings)}):")
+            for warning in self.warnings:
+                print(f"   • {warning}")
+
+        if all_passed and not self.errors:
+            print("\n✅ All rsync exclude tests passed!")
+        else:
+            print("\n❌ Some tests failed. Please fix the errors above.")
+
+        return all_passed and not self.errors
+
+
+def main():
+    """Run main function for command line usage."""
+    project_root = sys.argv[1] if len(sys.argv) > 1 else "."
+
+    tester = RsyncExcludesTest(project_root)
+    success = tester.run()
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduces separate exclude files to handle the asymmetric nature of pull vs push operations:

- .rsync-excludes-pull: Less restrictive, allows pulling .storage/ for local reference
- .rsync-excludes-push: More restrictive, protects all .storage/ files from being overwritten

Also enhances CLAUDE.md with:
- Instruction to consult latest HA docs before making changes
- Documentation of the rsync architecture
- Clear guidance on what can/cannot be managed via this module
- Workflow rules for before/during/after push operations
- WebSocket API examples for entity/device changes

Includes test suite for validating rsync exclude configurations.