### PR TITLE
Add auto-backup before pull/push with rotation and restore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ BACKUP_DIR=backups
 VENV_PATH=venv
 TOOLS_PATH=tools
 
+# Backup Configuration (optional)
+# MAX_BACKUPS: Maximum number of backups to retain (oldest are auto-deleted)
+MAX_BACKUPS=5
+
 # Instructions:
 # 1. Copy this file to .env in your project root: cp public/.env.example .env
 # 2. Edit .env with your actual Home Assistant details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,10 +72,16 @@ needed, make them manually in the Home Assistant UI:
 ## Available Commands
 
 ### Configuration Management
-- `make pull` - Pull latest config from Home Assistant instance
-- `make push` - Push local config to Home Assistant (with validation)
+- `make pull` - Pull latest config from Home Assistant instance (auto-backup first)
+- `make push` - Push local config to Home Assistant (with validation, auto-backup first)
 - `make backup` - Create backup of current config
 - `make validate` - Run all validation tests
+- `make list-backups` - List available backups with sizes
+- `make restore` - Restore most recent backup (or `make restore BACKUP=path`)
+
+### Backup Options
+- `SKIP_BACKUP=1` - Skip auto-backup (e.g., `make pull SKIP_BACKUP=1`)
+- `MAX_BACKUPS=N` - Max backups to retain (default: 5, set in `.env`)
 
 ### Validation Tools
 - `python tools/run_tests.py` - Run complete validation suite

--- a/README.md
+++ b/README.md
@@ -251,10 +251,18 @@ xcode-select --install  # Installs Command Line Tools including make
 
 ### Configuration Management
 ```bash
-make pull      # Pull latest config from Home Assistant
-make push      # Push local config to HA (with validation)
+make pull      # Pull latest config from Home Assistant (auto-backup first)
+make push      # Push local config to HA (with validation, auto-backup first)
 make backup    # Create timestamped backup
 make validate  # Run all validation tests
+```
+
+### Backup & Restore
+```bash
+make list-backups                    # List available backups with sizes
+make restore                         # Restore most recent backup
+make restore BACKUP=backups/file.tar.gz  # Restore specific backup
+make pull SKIP_BACKUP=1              # Skip auto-backup (e.g., first run)
 ```
 
 ### Entity Discovery
@@ -480,6 +488,9 @@ LOCAL_CONFIG_PATH=config/                # Local config directory
 BACKUP_DIR=backups                       # Backup directory
 VENV_PATH=venv                          # Python virtual environment path
 TOOLS_PATH=tools                        # Tools directory
+
+# Backup Configuration (optional)
+MAX_BACKUPS=5                           # Max backups to retain (oldest auto-deleted)
 ```
 
 ### Claude Code Settings


### PR DESCRIPTION
## Summary

- Automatically creates a timestamped backup of `config/` before every `make pull` and `make push`, so destructive rsync operations can be safely reverted
- Rotates old backups to keep only the most recent N (default 5, configurable via `MAX_BACKUPS`)
- Adds `make list-backups` to view available backups with sizes
- Adds `make restore` to restore from the most recent (or a specific) backup with a 5-second safety delay

## Test plan

- [ ] `make backup` creates a backup and rotates if count exceeds MAX_BACKUPS
- [ ] `make list-backups` lists backups sorted newest-first with sizes and count
- [ ] `make restore` restores the most recent backup after 5-second delay
- [ ] `make restore BACKUP=backups/specific.tar.gz` restores a named backup
- [ ] `make pull` creates a `pre-pull` backup before rsync
- [ ] `make pull SKIP_BACKUP=1` skips the auto-backup
- [ ] `make push` creates a `pre-push` backup after validation, before rsync
- [ ] Create 7 backups and verify only 5 remain after rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)