### PR TITLE
Upgrade HA to 2026.2.2, improve validator, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Verify rsync is available
         run: rsync --version
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install test dependencies
         run: pip install pytest pytest-cov pyyaml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install linters
         run: pip install flake8 black isort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,6 @@ mkdocs>=1.5.0
 mkdocs-material>=9.5.0
 
 # Home Assistant related
-homeassistant>=2024.1.0
+homeassistant==2026.2.2
 voluptuous>=0.14.0
 pyyaml>=6.0.0

--- a/tools/reference_validator.py
+++ b/tools/reference_validator.py
@@ -269,6 +269,9 @@ class ReferenceValidator:
         # Extract zone entities from configuration and storage
         entities.update(self._extract_zone_entities())
 
+        # Extract platform-based entities (calendar, etc.) from configuration.yaml
+        entities.update(self._extract_platform_entities())
+
         return entities
 
     def _extract_groups(self) -> Set[str]:
@@ -343,18 +346,21 @@ class ReferenceValidator:
                     sensor_data = data[sensor_type]
                     if isinstance(sensor_data, list):
                         for item in sensor_data:
-                            if isinstance(item, dict):
-                                # Platform-based sensors
-                                if (
-                                    "platform" in item
-                                    and item["platform"] == "template"
-                                ):
+                            if isinstance(item, dict) and "platform" in item:
+                                # Legacy template platform uses named keys
+                                if item["platform"] == "template":
                                     sensors = item.get("sensors", {})
                                     for name in sensors.keys():
                                         if isinstance(
                                             name, str
                                         ) and self._is_valid_object_id(name):
                                             entities.add(f"{sensor_type}.{name}")
+                                # Other platforms derive entity_id from name
+                                name = item.get("name")
+                                if isinstance(name, str):
+                                    object_id = self._slugify_object_id(name)
+                                    if object_id:
+                                        entities.add(f"{sensor_type}.{object_id}")
 
         except Exception:
             pass  # Ignore errors
@@ -529,6 +535,52 @@ class ReferenceValidator:
                                     entities.add(f"zone.{object_id}")
             except Exception:
                 pass
+
+        return entities
+
+    def _extract_platform_entities(self) -> Set[str]:
+        """Extract entities from YAML platform configurations (e.g., calendar).
+
+        Platform-based entities defined in YAML don't have unique IDs and
+        won't appear in the entity registry. Entity IDs are derived from
+        the platform's name fields (e.g., calendars list for CalDAV).
+        """
+        entities: Set[str] = set()
+        config_file = self.config_dir / "configuration.yaml"
+
+        if not config_file.exists():
+            return entities
+
+        try:
+            with open(config_file, "r", encoding="utf-8") as f:
+                data = yaml.load(f, Loader=HAYamlLoader)
+
+            if not isinstance(data, dict):
+                return entities
+
+            # Calendar platforms (CalDAV, etc.)
+            if "calendar" in data:
+                calendar_data = data["calendar"]
+                if isinstance(calendar_data, list):
+                    for item in calendar_data:
+                        if isinstance(item, dict):
+                            # CalDAV uses 'calendars' list of names
+                            calendars = item.get("calendars", [])
+                            if isinstance(calendars, list):
+                                for name in calendars:
+                                    if isinstance(name, str):
+                                        object_id = self._slugify_object_id(name)
+                                        if object_id:
+                                            entities.add(f"calendar.{object_id}")
+                            # Generic: platform with 'name' field
+                            name = item.get("name")
+                            if isinstance(name, str):
+                                object_id = self._slugify_object_id(name)
+                                if object_id:
+                                    entities.add(f"calendar.{object_id}")
+
+        except Exception:
+            pass
 
         return entities
 


### PR DESCRIPTION
## Summary
- **Upgrade homeassistant** from 2025.1.4 to 2026.2.2 — resolves false positives where template `cover` and `switch` entities were rejected by the offline validator due to the outdated HA schema
- **Require Python 3.13+** (HA 2025.2+ needs >= 3.13.2); CI updated from 3.11 to 3.13
- **Improve reference validator** to recognize YAML-defined platform entities (CalDAV calendars, statistics sensors, etc.) that exist at runtime but lack entity registry entries
- **Add Dependabot config** for weekly `pip` and `github-actions` dependency updates

## Note for maintainer
After merging, please **enable Dependabot** on the repo (Settings → Code security → Dependabot → Enable). The `.github/dependabot.yml` config is included but Dependabot needs to be activated in repo settings to start creating PRs.

## Test plan
- [x] `make validate` passes with HA 2026.2.2
- [x] Template cover/switch no longer flagged as invalid
- [x] CalDAV calendar and statistics sensor entities recognized by reference validator
- [x] CI passes with Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)