### PR TITLE
fix: resolve !include_dir_merge_list for template entity validation

### DIFF
--- a/tests/test_reference_validator.py
+++ b/tests/test_reference_validator.py
@@ -528,3 +528,152 @@ class TestBuiltinEntities:
         validator = ReferenceValidator(str(temp_config_dir))
 
         assert len(validator.BUILTIN_DOMAINS) == 0
+
+
+class TestIncludeDirMergeListTemplates:
+    """Tests for template entity extraction via !include_dir_merge_list and friends.
+
+    configuration.yaml commonly uses ``template: !include_dir_merge_list templates/``
+    to split template definitions across multiple files.  The custom YAML loader
+    represents those tags as plain strings, so the validator must resolve them
+    explicitly to discover the entities they define.
+    """
+
+    def _write_config_with_include(
+        self, config_dir: Path, directive: str = "!include_dir_merge_list templates/"
+    ) -> None:
+        """Write a configuration.yaml whose template key uses an include directive."""
+        # Write the raw string so it mimics what HAYamlLoader produces
+        (config_dir / "configuration.yaml").write_text(f"template: '{directive}'\n")
+
+    def test_sensor_in_template_file_recognised(self, temp_config_dir):
+        """Sensor defined in a templates/ file is treated as a valid entity."""
+        templates_dir = temp_config_dir / "templates"
+        templates_dir.mkdir()
+        climate_tmpl = [
+            {
+                "sensor": [
+                    {"name": "Heat Pump State", "state": "{{ 'off' }}"},
+                ]
+            }
+        ]
+        (templates_dir / "climate.yaml").write_text(yaml.dump(climate_tmpl))
+        self._write_config_with_include(temp_config_dir)
+
+        validator = ReferenceValidator(str(temp_config_dir))
+        entities = validator.get_config_defined_entities()
+
+        assert "sensor.heat_pump_state" in entities
+
+    def test_binary_sensor_in_template_file_recognised(self, temp_config_dir):
+        """Trigger-based binary_sensor defined in templates/ is recognised."""
+        templates_dir = temp_config_dir / "templates"
+        templates_dir.mkdir()
+        # Mirrors the real 'Cooling Config Changed' trigger template
+        trigger_tmpl = [
+            {
+                "trigger": [{"platform": "state", "entity_id": "input_boolean.foo"}],
+                "binary_sensor": [
+                    {"name": "Cooling Config Changed", "state": "{{ True }}"},
+                ],
+            }
+        ]
+        (templates_dir / "climate.yaml").write_text(yaml.dump(trigger_tmpl))
+        self._write_config_with_include(temp_config_dir)
+
+        validator = ReferenceValidator(str(temp_config_dir))
+        entities = validator.get_config_defined_entities()
+
+        assert "binary_sensor.cooling_config_changed" in entities
+
+    def test_multiple_template_files_all_scanned(self, temp_config_dir):
+        """Entities from all files in templates/ are discovered."""
+        templates_dir = temp_config_dir / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "climate.yaml").write_text(
+            yaml.dump(
+                [{"sensor": [{"name": "Indoor Temperature", "state": "{{ 20 }}"}]}]
+            )
+        )
+        (templates_dir / "energy.yaml").write_text(
+            yaml.dump(
+                [{"sensor": [{"name": "Excess Power L3", "state": "{{ 0.5 }}"}]}]
+            )
+        )
+        self._write_config_with_include(temp_config_dir)
+
+        validator = ReferenceValidator(str(temp_config_dir))
+        entities = validator.get_config_defined_entities()
+
+        assert "sensor.indoor_temperature" in entities
+        assert "sensor.excess_power_l3" in entities
+
+    def test_include_single_file_recognised(self, temp_config_dir):
+        """``template: '!include templates.yaml'`` is also resolved."""
+        single_tmpl = [
+            {"sensor": [{"name": "School Night Sensor", "state": "{{ True }}"}]}
+        ]
+        (temp_config_dir / "templates.yaml").write_text(yaml.dump(single_tmpl))
+        self._write_config_with_include(
+            temp_config_dir, directive="!include templates.yaml"
+        )
+
+        validator = ReferenceValidator(str(temp_config_dir))
+        entities = validator.get_config_defined_entities()
+
+        assert "sensor.school_night_sensor" in entities
+
+    def test_automation_referencing_template_entity_passes(self, temp_config_dir):
+        """Automation that uses a template-defined entity passes validation."""
+        templates_dir = temp_config_dir / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "presence.yaml").write_text(
+            yaml.dump(
+                [{"binary_sensor": [{"name": "School Night", "state": "{{ True }}"}]}]
+            )
+        )
+        self._write_config_with_include(temp_config_dir)
+
+        automations = [
+            {
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "binary_sensor.school_night",
+                    "to": "on",
+                },
+                "action": [],
+            }
+        ]
+        automations_file = temp_config_dir / "automations.yaml"
+        automations_file.write_text(yaml.dump(automations))
+
+        validator = ReferenceValidator(str(temp_config_dir))
+        assert validator.validate_file_references(automations_file)
+        assert not validator.errors
+
+    def test_unknown_entity_still_fails(self, temp_config_dir):
+        """A truly unknown entity still produces a validation error (regression guard)."""
+        templates_dir = temp_config_dir / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "climate.yaml").write_text(
+            yaml.dump([{"sensor": [{"name": "Known Sensor", "state": "{{ 1 }}"}]}])
+        )
+        self._write_config_with_include(temp_config_dir)
+
+        config = {
+            "automation": [
+                {
+                    "trigger": {
+                        "platform": "state",
+                        "entity_id": "sensor.does_not_exist",
+                    },
+                    "action": [],
+                }
+            ]
+        }
+        test_file = temp_config_dir / "test_config.yaml"
+        test_file.write_text(yaml.dump(config))
+
+        validator = ReferenceValidator(str(temp_config_dir))
+        assert not validator.validate_file_references(test_file)
+        assert "sensor.does_not_exist" in " ".join(validator.errors)

--- a/tools/reference_validator.py
+++ b/tools/reference_validator.py
@@ -336,6 +336,11 @@ class ReferenceValidator:
                         entities.update(self._extract_template_entities(item))
                 elif isinstance(template_data, dict):
                     entities.update(self._extract_template_entities(template_data))
+                elif isinstance(template_data, str) and template_data.startswith("!"):
+                    # Resolve !include, !include_dir_merge_list, !include_dir_list
+                    entities.update(
+                        self._extract_included_template_entities(template_data)
+                    )
 
             # Extract sensors/binary_sensors defined directly
             for sensor_type in ["sensor", "binary_sensor"]:
@@ -402,6 +407,57 @@ class ReferenceValidator:
                                 if object_id:
                                     entities.add(f"{entity_type}.{object_id}")
 
+        return entities
+
+    def _extract_included_template_entities(self, include_value: str) -> Set[str]:
+        """Extract template entities from !include_dir_merge_list / !include directives.
+
+        When configuration.yaml uses ``template: !include_dir_merge_list templates/``
+        the custom YAML loader stores the tag as a plain string instead of following
+        the reference.  This method resolves the directory or file and extracts
+        template entity IDs from the referenced YAML files.
+
+        Supports:
+        - ``!include_dir_merge_list <dir>``
+        - ``!include_dir_list <dir>``
+        - ``!include <file>``
+        """
+        entities: Set[str] = set()
+
+        dir_prefixes = [
+            "!include_dir_merge_list ",
+            "!include_dir_list ",
+        ]
+        for prefix in dir_prefixes:
+            if include_value.startswith(prefix):
+                dirname = include_value[len(prefix) :].strip()
+                dir_path = self.config_dir / dirname
+                if dir_path.is_dir():
+                    for yaml_file in sorted(dir_path.glob("**/*.yaml")):
+                        entities.update(self._load_template_file(yaml_file))
+                return entities
+
+        if include_value.startswith("!include "):
+            filename = include_value[len("!include ") :].strip()
+            file_path = self.config_dir / filename
+            if file_path.is_file():
+                entities.update(self._load_template_file(file_path))
+
+        return entities
+
+    def _load_template_file(self, yaml_file: Path) -> Set[str]:
+        """Load a single template YAML file and extract entity IDs from it."""
+        entities: Set[str] = set()
+        try:
+            with open(yaml_file, "r", encoding="utf-8") as f:
+                file_data = yaml.load(f, Loader=HAYamlLoader)
+            if isinstance(file_data, list):
+                for item in file_data:
+                    entities.update(self._extract_template_entities(item))
+            elif isinstance(file_data, dict):
+                entities.update(self._extract_template_entities(file_data))
+        except Exception:
+            pass  # Silently ignore — YAML errors are caught by yaml_validator
         return entities
 
     def _extract_automation_entities(self) -> Set[str]:


### PR DESCRIPTION
## Problem

The reference validator reported false-positive **"Unknown entity"** errors for every entity defined in template YAML files that are included via `template: !include_dir_merge_list templates/` in `configuration.yaml`.

**Root cause:** `HAYamlLoader` converts all `!include*` tags to plain strings (e.g. `"!include_dir_merge_list templates/"`). The `_extract_from_configuration` method checks `isinstance(template_data, list)` and `isinstance(template_data, dict)`, both of which are `False` for a string, so the templates directory was never scanned.

## Fix

Two new methods added to `ReferenceValidator`:

- **`_extract_included_template_entities(include_value)`** — detects `!include_dir_merge_list`, `!include_dir_list`, and `!include` strings and resolves them to actual files/directories.
- **`_load_template_file(yaml_file)`** — loads a single YAML file and passes each item to the existing `_extract_template_entities` helper.

`_extract_from_configuration` gains a new `elif` branch:
```python
elif isinstance(template_data, str) and template_data.startswith("!"):
    entities.update(self._extract_included_template_entities(template_data))
```

## Tests

6 new pytest cases in `TestIncludeDirMergeListTemplates`:

| Test | What it verifies |
|------|-----------------|
| `test_sensor_in_template_file_recognised` | Sensor from `templates/climate.yaml` is valid |
| `test_binary_sensor_in_template_file_recognised` | Trigger-based `binary_sensor` is valid |
| `test_multiple_template_files_all_scanned` | All files in `templates/` are scanned |
| `test_include_single_file_recognised` | `!include templates.yaml` (single file) works |
| `test_automation_referencing_template_entity_passes` | Full end-to-end validation passes |
| `test_unknown_entity_still_fails` | Truly unknown entities still produce errors |

All 28 tests pass (22 pre-existing + 6 new).