### PR TITLE
Fix reference_validator: resolve !include and support utility_meter

### DIFF
--- a/test_reference_validator.py
+++ b/test_reference_validator.py
@@ -465,5 +465,79 @@ class TestReferenceValidatorUUID(unittest.TestCase):
         self.assertEqual(len(self.validator.errors), 0)
 
 
+class TestConfigurationIncludes(unittest.TestCase):
+    """Entities declared in files pulled in via `!include` should be known."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.config_dir = Path(self.temp_dir)
+        (self.config_dir / ".storage").mkdir()
+        # Minimal empty registries — we only care about config-derived entities.
+        for name in ("core.entity_registry", "core.device_registry"):
+            (self.config_dir / ".storage" / name).write_text(
+                json.dumps({"version": 1, "data": {"entities": [], "devices": []}})
+            )
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def _write(self, relative: str, content: str) -> None:
+        (self.config_dir / relative).write_text(content)
+
+    def _extract(self) -> set[str]:
+        v = ReferenceValidator(str(self.config_dir))
+        return v.get_config_defined_entities()
+
+    def test_utility_meter_inline_creates_sensors(self):
+        self._write("configuration.yaml", yaml.safe_dump({
+            "utility_meter": {
+                "daily_import": {"source": "sensor.grid_energy", "cycle": "daily"},
+                "monthly_export": {"source": "sensor.grid_energy_returned",
+                                   "cycle": "monthly"},
+            }
+        }))
+        entities = self._extract()
+        self.assertIn("sensor.daily_import", entities)
+        self.assertIn("sensor.monthly_export", entities)
+
+    def test_utility_meter_include_is_followed(self):
+        self._write("configuration.yaml", "utility_meter: !include utility_meters.yaml\n")
+        self._write("utility_meters.yaml", yaml.safe_dump({
+            "net_metering_import": {"source": "sensor.grid"},
+            "net_metering_export": {"source": "sensor.grid_returned"},
+        }))
+        entities = self._extract()
+        self.assertIn("sensor.net_metering_import", entities)
+        self.assertIn("sensor.net_metering_export", entities)
+
+    def test_template_include_is_followed(self):
+        self._write("configuration.yaml", "template: !include templates.yaml\n")
+        self._write("templates.yaml", yaml.safe_dump([{
+            "sensor": [{
+                "name": "Net Balance",
+                "default_entity_id": "sensor.net_balance",
+                "state": "{{ 0 }}",
+            }]
+        }]))
+        entities = self._extract()
+        self.assertIn("sensor.net_balance", entities)
+
+    def test_input_helper_include_is_followed(self):
+        self._write("configuration.yaml", "input_number: !include input_numbers.yaml\n")
+        self._write("input_numbers.yaml", yaml.safe_dump({
+            "heater_target": {"min": 15, "max": 30, "step": 0.5},
+            "lights_brightness": {"min": 0, "max": 100},
+        }))
+        entities = self._extract()
+        self.assertIn("input_number.heater_target", entities)
+        self.assertIn("input_number.lights_brightness", entities)
+
+    def test_missing_include_file_is_silent(self):
+        self._write("configuration.yaml", "utility_meter: !include does_not_exist.yaml\n")
+        # Must not crash and must simply yield no utility_meter-derived entities.
+        entities = self._extract()
+        self.assertFalse(any(e.startswith("sensor.") for e in entities))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/reference_validator.py
+++ b/tools/reference_validator.py
@@ -291,6 +291,26 @@ class ReferenceValidator:
 
         return entities
 
+    def _resolve_include(self, value: Any) -> Any:
+        """Resolve an ``!include <filename>`` reference to its parsed contents.
+
+        ``HAYamlLoader`` stringifies ``!include foo.yaml`` as the literal
+        ``"!include foo.yaml"`` so the outer config stays readable. For entity
+        discovery we need the real data, so this helper loads the referenced
+        file on demand. Non-include values pass through unchanged.
+        """
+        if not isinstance(value, str) or not value.startswith("!include "):
+            return value
+        filename = value.split(" ", 1)[1].strip()
+        included_path = self.config_dir / filename
+        if not included_path.exists():
+            return None
+        try:
+            with open(included_path, "r", encoding="utf-8") as f:
+                return yaml.load(f, Loader=HAYamlLoader)
+        except Exception:
+            return None
+
     def _extract_from_configuration(self) -> Set[str]:
         """Extract entities defined in configuration.yaml."""
         entities: Set[str] = set()
@@ -314,7 +334,8 @@ class ReferenceValidator:
                     ):
                         entities.add(f"group.{group_name}")
 
-            # Extract input helpers
+            # Extract input helpers (with !include resolution so patterns like
+            # ``input_number: !include input_numbers.yaml`` are followed).
             for input_type in [
                 "input_boolean",
                 "input_number",
@@ -323,19 +344,34 @@ class ReferenceValidator:
                 "input_datetime",
                 "input_button",
             ]:
-                if input_type in data and isinstance(data[input_type], dict):
-                    for name in data[input_type].keys():
+                if input_type not in data:
+                    continue
+                helper_data = self._resolve_include(data[input_type])
+                if isinstance(helper_data, dict):
+                    for name in helper_data.keys():
                         if isinstance(name, str) and self._is_valid_object_id(name):
                             entities.add(f"{input_type}.{name}")
 
-            # Extract template entities
+            # Extract template entities (inline or !include).
             if "template" in data:
-                template_data = data["template"]
+                template_data = self._resolve_include(data["template"])
                 if isinstance(template_data, list):
                     for item in template_data:
                         entities.update(self._extract_template_entities(item))
                 elif isinstance(template_data, dict):
                     entities.update(self._extract_template_entities(template_data))
+
+            # Extract utility_meter entities. Each named block under the
+            # top-level ``utility_meter:`` key creates a ``sensor.<name>``
+            # entity. Supports inline or ``!include utility_meters.yaml``.
+            if "utility_meter" in data:
+                meter_data = self._resolve_include(data["utility_meter"])
+                if isinstance(meter_data, dict):
+                    for meter_name in meter_data.keys():
+                        if isinstance(meter_name, str) and self._is_valid_object_id(
+                            meter_name
+                        ):
+                            entities.add(f"sensor.{meter_name}")
 
             # Extract sensors/binary_sensors defined directly
             for sensor_type in ["sensor", "binary_sensor"]:


### PR DESCRIPTION
## Summary
- `make test` previously failed on this repo with 7 "Unknown entity" errors for entities declared via `!include` or produced by `utility_meter:` — both invisible to `reference_validator.py`.
- Teaches the validator to follow `!include` directives when extracting entities from `configuration.yaml`, and adds first-class support for `utility_meter:` blocks.
- No behavior change for configs that don't use `!include` for template/input helpers.

## Problem

`HAYamlLoader` intentionally stringifies `!include foo.yaml` as the literal `"!include foo.yaml"` so the loader can parse files that use HA-specific tags without chasing every include eagerly. `_extract_from_configuration` then only inspects the top level — so forward-declared entities like:

```yaml
template: !include templates.yaml
input_number: !include input_numbers.yaml
utility_meter: !include utility_meters.yaml
```

…were never discovered, and every reference to them from automations/scripts/templates was flagged as "Unknown entity".

On top of that, ``utility_meter:`` blocks create ``sensor.<name>`` entities but the validator had no extraction path for them at all.

## Changes

**`tools/reference_validator.py`**
- New `_resolve_include(value)` helper: when given an `!include <filename>` string, opens the referenced file relative to the config directory and returns its parsed contents. Returns the value unchanged for non-include inputs, and `None` for missing files.
- `_extract_from_configuration` now calls it for `template:` and each `input_*:` helper key.
- New extraction branch for top-level `utility_meter:` that emits `sensor.<meter_name>` for every named block — inline or `!include`.

**`test_reference_validator.py`**
- 5 new unit tests covering inline, `!include`, and missing-file paths across `utility_meter`, `template`, and `input_number`.
- Test suite grows from 25 → 30 tests, all passing.

## Test plan
- [x] Existing unit tests: `python -m unittest test_reference_validator test_validator_improvements` — 30/30 pass
- [x] `make test` on the real config previously failed with 7 "Unknown entity" errors; now exits 0
- [x] Dry-run against a config with no `!include` usage — behavior unchanged
- [x] Missing-include path exercised in tests (no crash, no false entities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)